### PR TITLE
Release/2.3.0

### DIFF
--- a/.env
+++ b/.env
@@ -9,7 +9,7 @@
 ################################################################
 
 ## Version
-DEVO_NG_RELAY_VERSION = 2.2.3
+DEVO_NG_RELAY_VERSION = 2.3.0
 
 ## Log level
 LOG_LEVEL = info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.2.1] -
+## [1.4.0] -
+
+- devo-ng-relay v2.3.0
+
+## [1.3.0] - 2022-09-13
+
+- devo-ng-relay v2.2.3
+- devo-ng-relay-cli v1.2.2
+
+## [1.2.1] - 2022-07-19
 
 - In docker compose V2 there is an [issue](https://github.com/docker/compose/issues/9410) 
 that was fixed in V1, but has been replicated again, so relative paths in named volumes 
 don't work. We have added a workaround until it gets fixed by docker compose team.
 
-## [1.2.0] - 
+## [1.2.0] - 2022-05-20
 
 - devo-ng-relay-cli v1.1.0
 - devo-ng-relay v2.1.0

--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ them. There is a short description of each of them below:
 
 | Name                  | Mandatory | Default Value | Description |
 | --------------------- | :-------: | :-----------: | ----------- |
-| NG_RELAY_VERSION      | Yes       | 2.0.2         | Version of the Devo NG-Relay. |
+| NG_RELAY_VERSION      | Yes       | 2.3.0         | Version of the Devo NG-Relay. |
 | LOG_LEVEL             | No        | info          | Sets the log level for the Devo NG-Relay. |
 | JAVA_OPTS             | No        | -Xmx1G -Xms1G | Space-separated quoted list in which you can activate/deactivate any of the JVM flags. |
 | TCP_PORT_RANGE        | No        | 13003-13020   | Used to open the TCP ports specified in all the user-defined rules. |
 | UDP_PORT_RANGE        | No        | 13003-13020   | Used to open the UDP ports specified in all the user-defined rules. |
-| NG_RELAY_CLI_VERSION  | Yes       | 1.0.0         | Version of the Devo NG-Relay CLI. |
+| NG_RELAY_CLI_VERSION  | Yes       | 1.2.2         | Version of the Devo NG-Relay CLI. |
 
 ## Start the relay
 


### PR DESCRIPTION
Update docker-compose with the new version of devo-ng-relay 2.3.0