### PR TITLE
Downgrade DEVO_NG_RELAY_VERSION to 2.13.3 - Fixes #24

### DIFF
--- a/.env
+++ b/.env
@@ -9,7 +9,7 @@
 ################################################################
 
 ## Version
-DEVO_NG_RELAY_VERSION = 2.15.1
+DEVO_NG_RELAY_VERSION = 2.13.3
 
 ## Log level
 LOG_LEVEL = info


### PR DESCRIPTION
Currently scoja server is not listening on 13000 port in version 2.15.1, Downgrading it to version 2.13.3 fixes the issue for now